### PR TITLE
POL-4140: fixed debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9.18-bullseye
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl openjdk-11-jre-headless graphviz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.18-bullseye
+FROM python:3.9-bullseye
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl openjdk-11-jre-headless graphviz \


### PR DESCRIPTION
Package `openjdk-11-jre-headless` is not available in `bookworm` debian. fix version to `bullseye`